### PR TITLE
Correct progress bar

### DIFF
--- a/farmer/src/components/ProgressBar.jsx
+++ b/farmer/src/components/ProgressBar.jsx
@@ -7,7 +7,7 @@ export const WEEKLY_BLOCK_NUMBER = 44800;
 
 export const ProgressBar = ({ currentPeriod, countdown, rightChain}) => {
     const isText = (!rightChain) || currentPeriod > TOTAL_CLAIM_PERIOD;
-    const value = isText ? 0 : ((1 + currentPeriod) * WEEKLY_BLOCK_NUMBER - countdown)/(TOTAL_CLAIM_PERIOD * WEEKLY_BLOCK_NUMBER) * 100;
+    const value = isText || currentPeriod === 0 ? 0 : (currentPeriod * WEEKLY_BLOCK_NUMBER - countdown)/(TOTAL_CLAIM_PERIOD * WEEKLY_BLOCK_NUMBER) * 100;
     
   return (
     <Box my={4}>


### PR DESCRIPTION
- Correct progress bar display: progress bar only moves during farming season: season 1 - season 13. 